### PR TITLE
Replace Pcre with Re.Pcre

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ocaml-lastfm
 
 
-This package contains an OCaml interface for Lastfm API interface. 
+This package contains an OCaml interface for Lastfm API interface.
 
 Please read the COPYING file before using this software.
 
@@ -14,7 +14,7 @@ Prerequisites:
 
 - ocaml-xmlplaylist >= 0.1.0
 
-- ocaml-pcre >= 5.12.2
+- ocaml-re
 
 - dune >= 2.0
 

--- a/dune-project
+++ b/dune-project
@@ -13,7 +13,7 @@
  (synopsis "The lastfm library is an implementation of the API used by the last.fm to keep count of played songs")
  (depends
   xmlplaylist
-  pcre
+  re
   (dune (>= 2.0)))
  (depopts
   ocamlnet))

--- a/lastfm.opam
+++ b/lastfm.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/savonet/ocaml-lastfm"
 bug-reports: "https://github.com/savonet/ocaml-lastfm/issues"
 depends: [
   "xmlplaylist"
-  "pcre"
+  "re"
   "dune" {>= "2.0"}
 ]
 depopts: ["ocamlnet"]

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,7 @@
  (public_name lastfm)
  (wrapped false)
  (libraries
-  pcre
+  re
   xmlplaylist
   (select
    lastfm.ml

--- a/src/lastfm_generic.ml
+++ b/src/lastfm_generic.ml
@@ -21,6 +21,7 @@
  *****************************************************************************)
 
 (* lastfm protocol API for ocaml *)
+module Pcre = Re.Pcre
 
 (* Records for client *)
 type client = { client : string; version : string }
@@ -89,8 +90,7 @@ let of_hex1 c =
 
 let url_decode ?(plus = true) s =
   Pcre.substitute
-    ~pat:
-      "\\+|%.."
+    ~rex:(Pcre.regexp "\\+|%..")
       (* TODO why do we match %. and % and seem to exclude them below ? *)
     ~subst:(fun s ->
       if s = "+" then if plus then " " else "+"
@@ -132,7 +132,7 @@ let to_hex2 =
     Bytes.to_string s
 
 let url_encode ?(plus = true) s =
-  Pcre.substitute ~pat:"[^A-Za-z0-9_.!*-]"
+  Pcre.substitute ~rex:(Pcre.regexp "[^A-Za-z0-9_.!*-]")
     ~subst:(fun x ->
       if plus && x = " " then "+"
       else (
@@ -293,7 +293,7 @@ module Audioscrobbler_generic (Http : Http_t) = struct
       in
       let test (p, e) =
         try
-          ignore (Pcre.exec ~pat:p s);
+          ignore (Pcre.exec ~rex:p s);
           raise (Error e)
         with Not_found -> ()
       in
@@ -367,7 +367,7 @@ module Audioscrobbler_generic (Http : Http_t) = struct
       let ans = request ?timeout ~host ~port req in
       let state, id, v =
         try
-          let lines = Pcre.split ~pat:"[\r\n]+" ans in
+          let lines = Pcre.split ~rex:(Pcre.regexp "[\r\n]+") ans in
           match lines with
             | [state; id; a; b] -> (state, id, (a, b))
             | _ -> raise (error_of_response ans)
@@ -564,7 +564,7 @@ module type Radio_t = sig
 end
 
 module Radio_generic (Http : Http_t) = struct
-  (* Type for track datas 
+  (* Type for track datas
    * A track is a list of "field","value" metadatas
    * and an uri *)
   type track = (string * string) list * string
@@ -668,7 +668,7 @@ module Radio_generic (Http : Http_t) = struct
     let values = Pcre.split ~rex s in
     let split s l =
       try
-        let sub = Pcre.exec ~pat:"([^=]*)=(.*)" s in
+        let sub = Pcre.exec ~rex:(Pcre.regexp "([^=]*)=(.*)") s in
         (Pcre.get_substring sub 1, Pcre.get_substring sub 2) :: l
       with Not_found -> l
     in
@@ -683,7 +683,7 @@ module Radio_generic (Http : Http_t) = struct
     with Not_found -> raise (Auth s)
 
   let adjust_pat = "response=OK"
-  let check_adjust s = Pcre.pmatch ~pat:adjust_pat s
+  let check_adjust s = Pcre.pmatch ~rex:(Pcre.regexp adjust_pat) s
   let opt_split_rex = Pcre.regexp "^([^?]+)\\?(.+)$"
 
   let opt_parse s =


### PR DESCRIPTION
Pcre has been removed from Debian, therefore preventing this from being migrating to testing or stable.